### PR TITLE
Updated allowed `status` for random post

### DIFF
--- a/commands/random-post.js
+++ b/commands/random-post.js
@@ -71,7 +71,7 @@ const setup = (sywac) => {
     });
     sywac.enumeration('--status', {
         defaultValue: 'published',
-        choices: ['public', 'draft', 'scheduled'],
+        choices: ['published', 'draft', 'scheduled', 'sent'],
         desc: 'Post status'
     });
     sywac.enumeration('--visibility', {


### PR DESCRIPTION
no refs

When using `--status published` with the `random-post` command an error was being thrown because `published` was not an allowed status. This commit updates the allowed statuses based on what the API allows.