### PR TITLE
Added clean slugs tool

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,6 +39,7 @@ import getPosts from '../commands/get-posts.js';
 import setTemplate from '../commands/set-template.js';
 import addMemberCompFromCSVCommands from '../commands/add-member-comp-from-csv.js';
 import setFeaturedImages from '../commands/set-featured-images.js';
+import cleanSlugs from '../commands/clean-slugs.js';
 
 prettyCLI.command(addMemberCompSubscriptionCommands);
 prettyCLI.command(removeMemberCompSubscriptionCommands);
@@ -76,6 +77,7 @@ prettyCLI.command(getPosts);
 prettyCLI.command(setTemplate);
 prettyCLI.command(addMemberCompFromCSVCommands);
 prettyCLI.command(setFeaturedImages);
+prettyCLI.command(cleanSlugs);
 
 prettyCLI.style({
     usageCommandPlaceholder: () => '<source or utility>'

--- a/commands/clean-slugs.js
+++ b/commands/clean-slugs.js
@@ -1,0 +1,68 @@
+import {ui} from '@tryghost/pretty-cli';
+import cleanSlugs from '../tasks/clean-slugs.js';
+
+// Internal ID in case we need one.
+const id = 'clean-slugs';
+
+const group = 'Content:';
+
+// The command to run and any params
+const flags = 'clean-slugs <apiURL> <adminAPIKey>';
+
+// Description for the top level command
+const desc = 'Find and remove alphanumeric IDs from post slugs';
+
+// Descriptions for the individual params
+const paramsDesc = [
+    'URL to your Ghost API',
+    'Admin API key'
+];
+
+// Configure all the options
+const setup = (sywac) => {
+    sywac.boolean('-V --verbose', {
+        defaultValue: false,
+        desc: 'Show verbose output'
+    });
+    sywac.boolean('--dry-run', {
+        defaultValue: false,
+        desc: 'Show what would be changed without making changes'
+    });
+    sywac.number('--delayBetweenCalls', {
+        defaultValue: 50,
+        desc: 'The delay between API calls, in ms'
+    });
+};
+
+// What to do when this command is executed
+const run = async (argv) => {
+    let timer = Date.now();
+    let context = {errors: []};
+
+    try {
+        // Fetch the tasks, configured correctly according to the options passed in
+        let runner = cleanSlugs.getTaskRunner(argv);
+
+        // Run the migration
+        await runner.run(context);
+    } catch (error) {
+        ui.log.error('Done with errors', context.errors);
+    }
+
+    // Report success
+    if (context.updated && context.updated.length > 0) {
+        ui.log.ok(`Successfully updated ${context.updated.length} slug${context.updated.length === 1 ? '' : 's'} in ${Date.now() - timer}ms.`);
+    } else {
+        ui.log.ok(`No slugs needed cleaning in ${Date.now() - timer}ms.`);
+    }
+};
+
+export default {
+    id,
+    group,
+    flags,
+    desc,
+    paramsDesc,
+    setup,
+    run
+}; 

--- a/tasks/clean-slugs.js
+++ b/tasks/clean-slugs.js
@@ -1,0 +1,165 @@
+import Promise from 'bluebird';
+import GhostAdminAPI from '@tryghost/admin-api';
+import {makeTaskRunner} from '@tryghost/listr-smart-renderer';
+
+import {ui} from '@tryghost/pretty-cli';
+import _ from 'lodash';
+import {discover} from '../lib/batch-ghost-discover.js';
+
+const initialise = (options) => {
+    return {
+        title: 'Initialising API connection',
+        task: (ctx, task) => {
+            let defaults = {
+                verbose: false,
+                dryRun: false,
+                delayBetweenCalls: 50
+            };
+
+            const url = options.apiURL.replace(/\/$/, '');
+            const key = options.adminAPIKey;
+            const api = new GhostAdminAPI({
+                url: url.replace('localhost', '127.0.0.1'),
+                key,
+                version: 'v5.0'
+            });
+
+            ctx.args = _.mergeWith(defaults, options);
+            
+            ctx.api = api;
+            ctx.posts = [];
+            ctx.postsWithIds = [];
+            ctx.updated = [];
+
+            // Regex to match alphanumeric IDs at the end of slugs (24+ characters)
+            // This matches strings like "684a32da145d7d001be71b4f" at the end of slugs
+            ctx.idRegex = /-([a-f0-9]{24,})$/i;
+
+            task.output = `Initialised API connection for ${options.apiURL}`;
+        }
+    };
+};
+
+const getFullTaskList = (options) => {
+    return [
+        initialise(options),
+        {
+            title: 'Fetch Posts from Ghost API',
+            task: async (ctx, task) => {
+                try {
+                    ctx.posts = await discover({
+                        api: ctx.api,
+                        type: 'posts',
+                        include: 'tags,authors'
+                    });
+
+                    task.output = `Found ${ctx.posts.length} posts`;
+                } catch (error) {
+                    ctx.errors.push(error);
+                    throw error;
+                }
+            }
+        },
+        {
+            title: 'Finding posts with IDs in slugs',
+            task: async (ctx, task) => {
+                ctx.postsWithIds = ctx.posts.filter((post) => {
+                    if (post.slug && ctx.idRegex.test(post.slug)) {
+                        const match = post.slug.match(ctx.idRegex);
+                        post.extractedId = match[1];
+                        post.cleanSlug = post.slug.replace(ctx.idRegex, '');
+                        return true;
+                    }
+                    return false;
+                });
+
+                task.output = `Found ${ctx.postsWithIds.length} posts with IDs in slugs`;
+
+                if (ctx.postsWithIds.length === 0) {
+                    task.output = 'No posts found with IDs in slugs';
+                    return;
+                }
+
+                // Display the posts found
+                if (ctx.args.verbose || ctx.postsWithIds.length <= 20) {
+                    ui.log.info('\nPosts with IDs in slugs:');
+                    ctx.postsWithIds.forEach((post) => {
+                        ui.log.info(`  • "${post.title}"`);
+                        ui.log.info(`    Current slug: ${post.slug}`);
+                        ui.log.info(`    Clean slug: ${post.cleanSlug}`);
+                        ui.log.info(`    Extracted ID: ${post.extractedId}`);
+                        ui.log.info('');
+                    });
+                } else {
+                    ui.log.info(`\nFound ${ctx.postsWithIds.length} posts with IDs in slugs. Use --verbose to see full list.`);
+                    ui.log.info('\nFirst 5 examples:');
+                    ctx.postsWithIds.slice(0, 5).forEach((post) => {
+                        ui.log.info(`  • "${post.title}": ${post.slug} → ${post.cleanSlug}`);
+                    });
+                }
+            }
+        },
+
+        {
+            title: 'Cleaning slugs',
+            skip: ctx => ctx.postsWithIds.length === 0,
+            task: async (ctx) => {
+                if (ctx.args['dry-run']) {
+                    ctx.updated = ctx.postsWithIds;
+                    ui.log.info('\n[DRY RUN] Would update the following slugs:');
+                    ctx.postsWithIds.forEach((post) => {
+                        ui.log.info(`  • "${post.title}": ${post.slug} → ${post.cleanSlug}`);
+                    });
+                    return;
+                }
+
+                let tasks = [];
+
+                await Promise.mapSeries(ctx.postsWithIds, async (post) => {
+                    tasks.push({
+                        title: `Updating "${post.title}": ${post.slug} → ${post.cleanSlug}`,
+                        task: async () => {
+                            try {
+                                // Update the post with the clean slug
+                                const updatedPost = {
+                                    id: post.id,
+                                    slug: post.cleanSlug,
+                                    updated_at: post.updated_at
+                                };
+
+                                let result = await ctx.api.posts.edit(updatedPost);
+                                ctx.updated.push(result);
+                                return Promise.delay(ctx.args.delayBetweenCalls).return(result);
+                            } catch (error) {
+                                error.resource = {
+                                    title: post.title,
+                                    slug: post.slug
+                                };
+                                ctx.errors.push(error);
+                                throw error;
+                            }
+                        }
+                    });
+                });
+
+                let taskOptions = options;
+                taskOptions.concurrent = 3;
+                return makeTaskRunner(tasks, taskOptions);
+            }
+        }
+    ];
+};
+
+const getTaskRunner = (options) => {
+    let tasks = [];
+
+    tasks = getFullTaskList(options);
+
+    return makeTaskRunner(tasks, Object.assign({topLevel: true}, options));
+};
+
+export default {
+    initialise,
+    getFullTaskList,
+    getTaskRunner
+}; 

--- a/test/clean-slugs.test.js
+++ b/test/clean-slugs.test.js
@@ -1,0 +1,174 @@
+import cleanSlugs from '../tasks/clean-slugs.js';
+
+describe('Clean Slugs', function () {
+    test('can identify posts with alphanumeric IDs at the end of slugs', function () {
+        // Test data with various slug formats
+        const testPosts = [
+            {
+                id: 1,
+                title: 'Test Post 1',
+                slug: 'my-great-post-684a32da145d7d001be71b4f',
+                updated_at: '2023-01-01T12:00:00.000Z'
+            },
+            {
+                id: 2,
+                title: 'Test Post 2',
+                slug: 'another-post-123abc456def789012345678',
+                updated_at: '2023-01-01T12:00:00.000Z'
+            },
+            {
+                id: 3,
+                title: 'Clean Post',
+                slug: 'clean-post-without-id',
+                updated_at: '2023-01-01T12:00:00.000Z'
+            },
+            {
+                id: 4,
+                title: 'Short ID Post',
+                slug: 'post-with-short-id-123',
+                updated_at: '2023-01-01T12:00:00.000Z'
+            },
+            {
+                id: 5,
+                title: 'Mixed Case ID',
+                slug: 'mixed-case-507f1f77bcf86cd799439011',
+                updated_at: '2023-01-01T12:00:00.000Z'
+            }
+        ];
+
+        // The regex used in the actual code
+        const idRegex = /-([a-f0-9]{24,})$/i;
+
+        const postsWithIds = testPosts.filter((post) => {
+            if (post.slug && idRegex.test(post.slug)) {
+                const match = post.slug.match(idRegex);
+                post.extractedId = match[1];
+                post.cleanSlug = post.slug.replace(idRegex, '');
+                return true;
+            }
+            return false;
+        });
+
+        // Should identify 3 posts with IDs (24+ character alphanumeric strings)
+        expect(postsWithIds).toBeArrayOfSize(3);
+
+        // Check first post
+        expect(postsWithIds[0].slug).toEqual('my-great-post-684a32da145d7d001be71b4f');
+        expect(postsWithIds[0].extractedId).toEqual('684a32da145d7d001be71b4f');
+        expect(postsWithIds[0].cleanSlug).toEqual('my-great-post');
+
+        // Check second post
+        expect(postsWithIds[1].slug).toEqual('another-post-123abc456def789012345678');
+        expect(postsWithIds[1].extractedId).toEqual('123abc456def789012345678');
+        expect(postsWithIds[1].cleanSlug).toEqual('another-post');
+
+        // Check third post (mixed case)
+        expect(postsWithIds[2].slug).toEqual('mixed-case-507f1f77bcf86cd799439011');
+        expect(postsWithIds[2].extractedId).toEqual('507f1f77bcf86cd799439011');
+        expect(postsWithIds[2].cleanSlug).toEqual('mixed-case');
+    });
+
+    test('regex correctly identifies valid alphanumeric IDs', function () {
+        const idRegex = /-([a-f0-9]{24,})$/i;
+
+        // Should match these
+        expect(idRegex.test('post-684a32da145d7d001be71b4f')).toBe(true);
+        expect(idRegex.test('test-123abc456def789012345678')).toBe(true);
+        expect(idRegex.test('mixed-507F1F77BCF86CD799439011')).toBe(true); // uppercase
+        expect(idRegex.test('long-507f1f77bcf86cd799439011abcdef123456')).toBe(true); // longer than 24
+
+        // Should NOT match these
+        expect(idRegex.test('post-without-id')).toBe(false);
+        expect(idRegex.test('post-123')).toBe(false); // too short
+        expect(idRegex.test('post-123xyz')).toBe(false); // contains invalid chars
+        expect(idRegex.test('post-123-456-789')).toBe(false); // contains dashes
+        expect(idRegex.test('post-GHIJKLMNOPQRSTUVWXYZ123456')).toBe(false); // contains G-Z
+    });
+
+    test('regex extracts correct ID and produces clean slug', function () {
+        const idRegex = /-([a-f0-9]{24,})$/i;
+        
+        const testCases = [
+            {
+                input: 'my-awesome-post-684a32da145d7d001be71b4f',
+                expectedId: '684a32da145d7d001be71b4f',
+                expectedClean: 'my-awesome-post'
+            },
+            {
+                input: 'single-word-507f1f77bcf86cd799439011',
+                expectedId: '507f1f77bcf86cd799439011',
+                expectedClean: 'single-word'
+            },
+            {
+                input: 'a-b-c-d-e-f-123abc456def789012345678',
+                expectedId: '123abc456def789012345678',
+                expectedClean: 'a-b-c-d-e-f'
+            }
+        ];
+
+        testCases.forEach((testCase) => {
+            const match = testCase.input.match(idRegex);
+            expect(match).not.toBeNull();
+            expect(match[1]).toEqual(testCase.expectedId);
+            
+            const cleanSlug = testCase.input.replace(idRegex, '');
+            expect(cleanSlug).toEqual(testCase.expectedClean);
+        });
+    });
+
+    test('handles edge cases correctly', function () {
+        const idRegex = /-([a-f0-9]{24,})$/i;
+
+        // Edge cases that should NOT match
+        const edgeCases = [
+            '', // empty string
+            'no-dashes', // no dash at all
+            'ends-with-dash-', // ends with dash but no ID
+            'has-g-in-id-684a32da145d7d001be71b4g', // contains 'g'
+            'too-short-684a32da145d7d001be71b', // 23 chars (too short)
+            'invalid-chars-684a32da145d7d001be71xyz' // contains 'x', 'y', 'z'
+        ];
+
+        edgeCases.forEach((edgeCase) => {
+            expect(idRegex.test(edgeCase)).toBe(false);
+        });
+    });
+
+    test('initialise function sets up context correctly', function () {
+        // Use a valid Ghost API key format: {24 hex chars}:{64 hex chars}
+        const options = {
+            apiURL: 'https://test.ghost.io',
+            adminAPIKey: '507f1f77bcf86cd799439011:507f1f77bcf86cd7994390117bcf86cd7994390117bcf86cd7994390117bcf86cd',
+            verbose: true,
+            'dry-run': false,
+            delayBetweenCalls: 100
+        };
+
+        const initTask = cleanSlugs.initialise(options);
+        
+        expect(initTask).toBeObject();
+        expect(initTask.title).toEqual('Initialising API connection');
+        expect(initTask.task).toBeFunction();
+
+        // Mock task context
+        const ctx = {};
+        const task = {output: ''};
+        
+        // Run the initialization
+        initTask.task(ctx, task);
+
+        // Check that context is set up correctly
+        expect(ctx.args).toBeObject();
+        expect(ctx.api).toBeObject();
+        expect(ctx.posts).toBeArray();
+        expect(ctx.postsWithIds).toBeArray();
+        expect(ctx.updated).toBeArray();
+        expect(ctx.idRegex).toBeInstanceOf(RegExp);
+        
+        // Check that the regex pattern is correct
+        expect(ctx.idRegex.source).toEqual('-([a-f0-9]{24,})$');
+        expect(ctx.idRegex.flags).toEqual('i');
+        
+        expect(task.output).toEqual('Initialised API connection for https://test.ghost.io');
+    });
+}); 


### PR DESCRIPTION
Occasionally on import Ghost adds a 24 character alphanumeric id to the end of the slug. We don't know why, and it is rare, but this tool allows us to remove these in bulk when it happens.