### PR TITLE
Added set-podcast tool

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,6 +39,7 @@ import getPosts from '../commands/get-posts.js';
 import setTemplate from '../commands/set-template.js';
 import addMemberCompFromCSVCommands from '../commands/add-member-comp-from-csv.js';
 import setFeaturedImages from '../commands/set-featured-images.js';
+import setPodcast from '../commands/set-podcast.js';
 
 prettyCLI.command(addMemberCompSubscriptionCommands);
 prettyCLI.command(removeMemberCompSubscriptionCommands);
@@ -76,6 +77,7 @@ prettyCLI.command(getPosts);
 prettyCLI.command(setTemplate);
 prettyCLI.command(addMemberCompFromCSVCommands);
 prettyCLI.command(setFeaturedImages);
+prettyCLI.command(setPodcast);
 
 prettyCLI.style({
     usageCommandPlaceholder: () => '<source or utility>'

--- a/commands/set-podcast.js
+++ b/commands/set-podcast.js
@@ -1,0 +1,60 @@
+import {ui} from '@tryghost/pretty-cli';
+import setPodcast from '../tasks/set-podcast.js';
+
+// Internal ID in case we need one.
+const id = 'set-podcast';
+
+const group = 'Content:';
+
+// The command to run and any params
+const flags = 'set-podcast <apiURL> <adminAPIKey>';
+
+// Description for the top level command
+const desc = 'Set Facebook description for podcast posts using the first audio src URL from the post content';
+
+// Descriptions for the individual params
+const paramsDesc = [
+    'URL to your Ghost API',
+    'Admin API key'
+];
+
+// Configure all the options
+const setup = (sywac) => {
+    sywac.boolean('-V --verbose', {
+        defaultValue: false,
+        desc: 'Show verbose output'
+    });
+    sywac.number('--delayBetweenCalls', {
+        defaultValue: 50,
+        desc: 'The delay between API calls, in ms'
+    });
+};
+
+// What to do when this command is executed
+const run = async (argv) => {
+    let timer = Date.now();
+    let context = {errors: []};
+
+    try {
+        // Fetch the tasks, configured correctly according to the options passed in
+        let runner = setPodcast.getTaskRunner(argv);
+
+        // Run the migration
+        await runner.run(context);
+    } catch (error) {
+        ui.log.error('Done with errors', context.errors);
+    }
+
+    // Report success
+    ui.log.ok(`Successfully processed ${context.processed} posts in ${Date.now() - timer}ms.`);
+};
+
+export default {
+    id,
+    group,
+    flags,
+    desc,
+    paramsDesc,
+    setup,
+    run
+}; 

--- a/tasks/set-podcast.js
+++ b/tasks/set-podcast.js
@@ -1,0 +1,275 @@
+import GhostAdminAPI from '@tryghost/admin-api';
+import {makeTaskRunner} from '@tryghost/listr-smart-renderer';
+import _ from 'lodash';
+import {discover} from '../lib/batch-ghost-discover.js';
+
+const initialise = (options) => {
+    return {
+        title: 'Initialising API connection',
+        task: (ctx, task) => {
+            let defaults = {
+                verbose: false,
+                delayBetweenCalls: 50
+            };
+
+            const url = options.apiURL.replace(/\/$/, '');
+            const key = options.adminAPIKey;
+            const api = new GhostAdminAPI({
+                url: url.replace('localhost', '127.0.0.1'),
+                key,
+                version: 'v5.0'
+            });
+
+            ctx.args = _.mergeWith(defaults, options);
+            ctx.api = api;
+            ctx.processed = 0;
+            ctx.updated = 0;
+            ctx.errors = [];
+
+            task.output = 'API connection initialised';
+        }
+    };
+};
+
+/**
+ * Extracts the first audio URL from HTML content
+ * @param {string} html - The HTML content to search in
+ * @returns {string|null} The first audio URL found, or null if no audio is found
+ */
+const extractFirstAudio = (html) => {
+    // Look for audio tags first
+    const audioRegex = /<audio[^>]+src="([^">]+)"/;
+    const audioMatch = html.match(audioRegex);
+    if (audioMatch) {
+        return audioMatch[1];
+    }
+    
+    // Look for audio cards (common pattern in Ghost)
+    const audioCardRegex = /<div[^>]*class="[^"]*audio[^"]*"[^>]*>[\s\S]*?src="([^">]+)"/i;
+    const audioCardMatch = html.match(audioCardRegex);
+    if (audioCardMatch) {
+        return audioCardMatch[1];
+    }
+    
+    // Look for iframe with audio content (like SoundCloud, Spotify, etc.)
+    const iframeRegex = /<iframe[^>]+src="([^">]*(?:soundcloud|spotify|anchor|buzzsprout|simplecast|libsyn)[^">]*)"/i;
+    const iframeMatch = html.match(iframeRegex);
+    if (iframeMatch) {
+        return iframeMatch[1];
+    }
+    
+    return null;
+};
+
+/**
+ * Extracts the first audio URL from Lexical content
+ * @param {string} lexical - The Lexical content
+ * @returns {string|null} The first audio URL found, or null if no audio is found
+ */
+const extractFirstAudioFromLexical = (lexical) => {
+    try {
+        const content = JSON.parse(lexical);
+        
+        // Look for audio nodes in Lexical content
+        const findAudioInNodes = (nodes) => {
+            for (const node of nodes) {
+                if (node.type === 'audio' && node.src) {
+                    return node.src;
+                }
+                
+                // Check for embed nodes with audio content
+                if (node.type === 'embed' && node.url) {
+                    if (node.url.includes('soundcloud') || 
+                        node.url.includes('spotify') || 
+                        node.url.includes('anchor') ||
+                        node.url.includes('buzzsprout') ||
+                        node.url.includes('simplecast') ||
+                        node.url.includes('libsyn')) {
+                        return node.url;
+                    }
+                }
+                
+                // Recursively check children
+                if (node.children && Array.isArray(node.children)) {
+                    const childAudio = findAudioInNodes(node.children);
+                    if (childAudio) {
+                        return childAudio;
+                    }
+                }
+            }
+            return null;
+        };
+        
+        return findAudioInNodes(content.root.children);
+    } catch (error) {
+        return null;
+    }
+};
+
+/**
+ * Extracts the first audio URL from Mobiledoc content
+ * @param {string} mobiledoc - The Mobiledoc content
+ * @returns {string|null} The first audio URL found, or null if no audio is found
+ */
+const extractFirstAudioFromMobiledoc = (mobiledoc) => {
+    try {
+        const content = JSON.parse(mobiledoc);
+        
+        // Look for audio cards in Mobiledoc
+        const audioCard = content.cards.find((card) => {
+            return card[0] === 'audio' || 
+                   card[0] === 'embed' || 
+                   card[0] === 'html';
+        });
+        
+        if (audioCard) {
+            const cardData = audioCard[1];
+            
+            // Direct audio card
+            if (audioCard[0] === 'audio' && cardData.src) {
+                return cardData.src;
+            }
+            
+            // Embed card with audio content
+            if (audioCard[0] === 'embed' && cardData.url) {
+                if (cardData.url.includes('soundcloud') || 
+                    cardData.url.includes('spotify') || 
+                    cardData.url.includes('anchor') ||
+                    cardData.url.includes('buzzsprout') ||
+                    cardData.url.includes('simplecast') ||
+                    cardData.url.includes('libsyn')) {
+                    return cardData.url;
+                }
+            }
+            
+            // HTML card with audio content
+            if (audioCard[0] === 'html' && cardData.html) {
+                return extractFirstAudio(cardData.html);
+            }
+        }
+        
+        return null;
+    } catch (error) {
+        return null;
+    }
+};
+
+const getFullTaskList = (options) => {
+    return [
+        initialise(options),
+        {
+            title: 'Fetching posts with podcast tag',
+            task: async (ctx, task) => {
+                let postDiscoveryOptions = {
+                    api: ctx.api,
+                    type: 'posts',
+                    limit: 100,
+                    include: 'tags,authors',
+                    filter: 'tag:[podcast]',
+                    progress: (options.verbose) ? true : false
+                };
+
+                try {
+                    ctx.posts = await discover(postDiscoveryOptions);
+                    task.output = `Found ${ctx.posts.length} posts with podcast tag`;
+                } catch (error) {
+                    ctx.errors.push(error);
+                    throw error;
+                }
+            }
+        },
+        {
+            title: 'Processing posts and setting Facebook descriptions',
+            task: async (ctx, task) => {
+                for (const post of ctx.posts) {
+                    try {
+                        if (options.verbose) {
+                            task.output = `Processing post "${post.title}"`;
+                        }
+                        
+                        let firstAudio = null;
+                        
+                        // Try Lexical first
+                        if (post.lexical) {
+                            firstAudio = extractFirstAudioFromLexical(post.lexical);
+                            if (options.verbose && firstAudio) {
+                                task.output = `Found audio in Lexical content: ${firstAudio}`;
+                            }
+                        }
+                        
+                        // If no audio found in Lexical, try Mobiledoc
+                        if (!firstAudio && post.mobiledoc) {
+                            firstAudio = extractFirstAudioFromMobiledoc(post.mobiledoc);
+                            if (options.verbose && firstAudio) {
+                                task.output = `Found audio in Mobiledoc content: ${firstAudio}`;
+                            }
+                        }
+                        
+                        // If still no audio, try HTML as fallback
+                        if (!firstAudio && post.html) {
+                            firstAudio = extractFirstAudio(post.html);
+                            if (options.verbose && firstAudio) {
+                                task.output = `Found audio in HTML content: ${firstAudio}`;
+                            }
+                        }
+                        
+                        if (firstAudio) {
+                            if (options.verbose) {
+                                task.output = `Updating post "${post.title}" with Facebook description: ${firstAudio}`;
+                            }
+                            
+                            await ctx.api.posts.edit({
+                                id: post.id,
+                                og_description: firstAudio,
+                                title: post.title,
+                                status: post.status,
+                                updated_at: post.updated_at
+                            });
+                            ctx.updated = ctx.updated + 1;
+                            
+                            if (options.verbose) {
+                                task.output = `Successfully updated post "${post.title}" with Facebook description: ${firstAudio}`;
+                            }
+                        } else if (options.verbose) {
+                            task.output = `No audio found in post "${post.title}"`;
+                        }
+                        
+                        ctx.processed = ctx.processed + 1;
+                        
+                        // Add delay between API calls
+                        if (ctx.args.delayBetweenCalls > 0) {
+                            await new Promise((resolve) => {
+                                setTimeout(resolve, ctx.args.delayBetweenCalls);
+                            });
+                        }
+                    } catch (error) {
+                        ctx.errors.push(`Error processing post "${post.title}": ${error.message}`);
+                        if (options.verbose) {
+                            task.output = `Error processing post "${post.title}": ${error.message}`;
+                        }
+                    }
+                }
+                
+                task.output = `Processed ${ctx.processed} posts, updated ${ctx.updated} with Facebook descriptions`;
+            }
+        }
+    ];
+};
+
+const getTaskRunner = (options) => {
+    let tasks = [];
+    tasks = getFullTaskList(options);
+    return makeTaskRunner(tasks, Object.assign({topLevel: true}, options));
+};
+
+export {
+    extractFirstAudio,
+    extractFirstAudioFromLexical,
+    extractFirstAudioFromMobiledoc
+};
+
+export default {
+    initialise,
+    getFullTaskList,
+    getTaskRunner
+}; 

--- a/test/set-podcast.test.js
+++ b/test/set-podcast.test.js
@@ -1,0 +1,280 @@
+import {jest} from '@jest/globals';
+
+// Mock the Ghost Admin API
+const mockPosts = [
+    {
+        id: '1',
+        title: 'Podcast with Lexical audio',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        lexical: JSON.stringify({
+            root: {
+                children: [
+                    {
+                        type: 'audio',
+                        src: 'https://example.com/podcast1.mp3'
+                    }
+                ]
+            }
+        })
+    },
+    {
+        id: '2',
+        title: 'Podcast with Lexical embed',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        lexical: JSON.stringify({
+            root: {
+                children: [
+                    {
+                        type: 'embed',
+                        url: 'https://soundcloud.com/example/podcast-episode'
+                    }
+                ]
+            }
+        })
+    },
+    {
+        id: '3',
+        title: 'Podcast with Mobiledoc audio',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        mobiledoc: JSON.stringify({
+            cards: [
+                ['audio', {src: 'https://example.com/podcast2.mp3'}]
+            ]
+        })
+    },
+    {
+        id: '4',
+        title: 'Podcast with Mobiledoc embed',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        mobiledoc: JSON.stringify({
+            cards: [
+                ['embed', {url: 'https://anchor.fm/example/episodes/episode-1'}]
+            ]
+        })
+    },
+    {
+        id: '5',
+        title: 'Podcast with HTML audio tag',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        html: '<audio src="https://example.com/podcast3.mp3" controls></audio>'
+    },
+    {
+        id: '6',
+        title: 'Podcast with iframe embed',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        html: '<iframe src="https://spotify.com/embed/episode/123" width="100%" height="152"></iframe>'
+    },
+    {
+        id: '7',
+        title: 'Podcast with no audio',
+        status: 'published',
+        updated_at: '2024-03-20T12:00:00.000Z',
+        tags: [{name: 'podcast', slug: 'podcast'}],
+        html: '<p>This podcast post has no audio content</p>'
+    }
+];
+
+const mockApi = {
+    posts: {
+        browse: jest.fn(), // not used in test, but required for API shape
+        edit: jest.fn().mockImplementation((data) => {
+            return Promise.resolve(data);
+        })
+    }
+};
+
+jest.unstable_mockModule('@tryghost/admin-api', () => ({
+    default: jest.fn().mockImplementation(() => mockApi)
+}));
+jest.unstable_mockModule('../lib/batch-ghost-discover.js', () => ({
+    discover: jest.fn().mockResolvedValue(mockPosts)
+}));
+
+describe('Set podcast', function () {
+    beforeEach(() => {
+        // Reset mocks
+        jest.clearAllMocks();
+    });
+
+    test('can extract audio from Lexical content with direct audio node', async function () {
+        const {extractFirstAudioFromLexical} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudioFromLexical(mockPosts[0].lexical);
+        expect(audio).toBe('https://example.com/podcast1.mp3');
+    });
+
+    test('can extract audio from Lexical content with embed node', async function () {
+        const {extractFirstAudioFromLexical} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudioFromLexical(mockPosts[1].lexical);
+        expect(audio).toBe('https://soundcloud.com/example/podcast-episode');
+    });
+
+    test('can extract audio from Mobiledoc content with audio card', async function () {
+        const {extractFirstAudioFromMobiledoc} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudioFromMobiledoc(mockPosts[2].mobiledoc);
+        expect(audio).toBe('https://example.com/podcast2.mp3');
+    });
+
+    test('can extract audio from Mobiledoc content with embed card', async function () {
+        const {extractFirstAudioFromMobiledoc} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudioFromMobiledoc(mockPosts[3].mobiledoc);
+        expect(audio).toBe('https://anchor.fm/example/episodes/episode-1');
+    });
+
+    test('can extract audio from HTML content with audio tag', async function () {
+        const {extractFirstAudio} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudio(mockPosts[4].html);
+        expect(audio).toBe('https://example.com/podcast3.mp3');
+    });
+
+    test('can extract audio from HTML content with iframe embed', async function () {
+        const {extractFirstAudio} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudio(mockPosts[5].html);
+        expect(audio).toBe('https://spotify.com/embed/episode/123');
+    });
+
+    test('returns null when no audio is found in HTML', async function () {
+        const {extractFirstAudio} = await import('../tasks/set-podcast.js');
+        const audio = extractFirstAudio(mockPosts[6].html);
+        expect(audio).toBeNull();
+    });
+
+    test('returns null when no audio is found in Lexical', async function () {
+        const {extractFirstAudioFromLexical} = await import('../tasks/set-podcast.js');
+        const lexicalWithoutAudio = JSON.stringify({
+            root: {
+                children: [
+                    {
+                        type: 'paragraph',
+                        children: [{type: 'text', text: 'No audio here'}]
+                    }
+                ]
+            }
+        });
+        const audio = extractFirstAudioFromLexical(lexicalWithoutAudio);
+        expect(audio).toBeNull();
+    });
+
+    test('returns null when no audio is found in Mobiledoc', async function () {
+        const {extractFirstAudioFromMobiledoc} = await import('../tasks/set-podcast.js');
+        const mobiledocWithoutAudio = JSON.stringify({
+            cards: [
+                ['paragraph', {text: 'No audio here'}]
+            ]
+        });
+        const audio = extractFirstAudioFromMobiledoc(mobiledocWithoutAudio);
+        expect(audio).toBeNull();
+    });
+
+    test('can process posts and set Facebook descriptions', async function () {
+        const setPodcastModule = await import('../tasks/set-podcast.js');
+        const runner = setPodcastModule.default.getTaskRunner({
+            apiURL: 'https://example.com',
+            adminAPIKey: 'key',
+            verbose: true
+        });
+
+        const context = {errors: []};
+        await runner.run(context);
+
+        // Should have processed all posts
+        expect(context.processed).toBe(7);
+        // Should have updated 6 posts (the one with no audio should be skipped)
+        expect(context.updated).toBe(6);
+        // Should have no errors
+        expect(context.errors).toHaveLength(0);
+
+        // Verify edit calls for each post with audio
+        expect(mockApi.posts.edit).toHaveBeenCalledTimes(6);
+        expect(mockApi.posts.edit).toHaveBeenCalledWith({
+            id: '1',
+            og_description: 'https://example.com/podcast1.mp3',
+            title: 'Podcast with Lexical audio',
+            status: 'published',
+            updated_at: '2024-03-20T12:00:00.000Z'
+        });
+        expect(mockApi.posts.edit).toHaveBeenCalledWith({
+            id: '2',
+            og_description: 'https://soundcloud.com/example/podcast-episode',
+            title: 'Podcast with Lexical embed',
+            status: 'published',
+            updated_at: '2024-03-20T12:00:00.000Z'
+        });
+    });
+
+    test('handles API errors gracefully', async function () {
+        // Make the edit call fail for one post
+        mockApi.posts.edit.mockRejectedValueOnce({message: 'API Error'});
+
+        const setPodcastModule = await import('../tasks/set-podcast.js');
+        const runner = setPodcastModule.default.getTaskRunner({
+            apiURL: 'https://example.com',
+            adminAPIKey: 'key',
+            verbose: true
+        });
+
+        const context = {errors: []};
+        await runner.run(context);
+
+        // Should still process remaining posts after the error
+        expect(context.processed).toBe(6);
+        // Should have one error
+        expect(context.errors).toHaveLength(1);
+        expect(context.errors[0]).toContain('API Error');
+    });
+
+    test('handles invalid JSON gracefully', async function () {
+        const {extractFirstAudioFromLexical, extractFirstAudioFromMobiledoc} = await import('../tasks/set-podcast.js');
+        
+        const invalidJson = 'invalid json string';
+        
+        expect(extractFirstAudioFromLexical(invalidJson)).toBeNull();
+        expect(extractFirstAudioFromMobiledoc(invalidJson)).toBeNull();
+    });
+
+    test('handles nested Lexical content', async function () {
+        const {extractFirstAudioFromLexical} = await import('../tasks/set-podcast.js');
+        
+        const nestedLexical = JSON.stringify({
+            root: {
+                children: [
+                    {
+                        type: 'paragraph',
+                        children: [
+                            {
+                                type: 'audio',
+                                src: 'https://example.com/nested-audio.mp3'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        
+        const audio = extractFirstAudioFromLexical(nestedLexical);
+        expect(audio).toBe('https://example.com/nested-audio.mp3');
+    });
+
+    test('prioritizes audio over other podcast platforms in detection', async function () {
+        const {extractFirstAudio} = await import('../tasks/set-podcast.js');
+        
+        const htmlWithMultiple = `
+            <iframe src="https://spotify.com/embed/episode/123"></iframe>
+            <audio src="https://example.com/direct-audio.mp3" controls></audio>
+        `;
+        
+        const audio = extractFirstAudio(htmlWithMultiple);
+        expect(audio).toBe('https://example.com/direct-audio.mp3');
+    });
+}); 


### PR DESCRIPTION
no ref

Added set-podcast tool allowing us to bulk set facebook descriptions from the first audio card in posts tagged podcast. Useful for post substack migrations