### PR TITLE
zip-create: remove `images` in zip path

### DIFF
--- a/tasks/zip-create.js
+++ b/tasks/zip-create.js
@@ -85,7 +85,7 @@ const getFullTaskList = (options) => {
             task: async (ctx) => {
                 // 1. Copy the directory
                 try {
-                    let res = await fs.copy(ctx.args.dirPath, `${ctx.fileCache.tmpDir}/images`);
+                    let res = await fs.copy(ctx.args.dirPath, `${ctx.fileCache.tmpDir}`);
                     return res;
                 } catch (error) {
                     ctx.errors.push(error);


### PR DESCRIPTION
The tool must not alter file paths between the local directory and what will be served by the Ghost instance.

On the "Copy the directory" task, an `/images` is added to the destination temporary path. This addition changes the path of files that is preserved by the zipping process.
This results in an incorrect path on the Ghost instance once uploaded, as the import process preserves paths.