### PR TITLE
zip-create: await zip writing before ending tasks

### DIFF
--- a/tasks/zip-create.js
+++ b/tasks/zip-create.js
@@ -55,7 +55,7 @@ async function createZip(chunk, index, ctx) {
     const zipFileParts = parse(ctx.args.dirPath);
     const zipName = `${zipFileParts.name}_${index}.zip`;
 
-    fsUtils.zip.write(ctx.fileCache.zipDir, chunk, zipName);
+    await fsUtils.zip.write(ctx.fileCache.zipDir, chunk, zipName);
 }
 
 const initialise = (options) => {
@@ -157,8 +157,6 @@ const getFullTaskList = (options) => {
                 try {
                     let chunkDirs = globSync(`${ctx.fileCache.zipDir}/chunks/*`);
 
-                    // This does not work properly, and is still trying to create the zip file when the tmp dir has been deleted
-                    // When resolved, re-enable the 'Cleaning up' task
                     await Promise.all(chunkDirs.map((dir, index) => {
                         return createZip(dir, index, ctx);
                     }));
@@ -190,7 +188,6 @@ const getFullTaskList = (options) => {
         },
         {
             title: 'Cleaning up',
-            skip: () => true,
             task: async (ctx) => {
                 // 7. Remove the cached data
                 try {


### PR DESCRIPTION
The `createZip` function, called for each chunk, is asynchronous. While `createZip` calls are correctly awaited within `Promise.all()`, the internal call to `fsUtils.zip.write` is not awaited. This function is also asynchronous:
https://github.com/TryGhost/migrate/blob/7686d2d3be174fde8ebbc78699aa7b3e7b89d7e4/packages/mg-fs-utils/lib/zip.js#L57

This omission caused the Zipping chunks task to exit prematurely, without waiting the end of zip file creation.
With this fix the comment is not needed and the cleanup task can be re-activated.