### PR TITLE
Added --ignore-scripts flag to yarn install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - run: yarn install
+      - run: yarn install --ignore-scripts
       - run: yarn test


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- there have been multiple recent npm incidents with compromised packages using pre/post-install scripts to run malicious scripts
- we want to default to not running these scripts as a security precaution, this matches behaviour of pnpm which is touted as a modern, more secure, npm package manager