### PR TITLE
Add export-comments tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,36 @@ The JSON file should be in the standard Ghost export format (`{db: [{data: {post
 - `--delayBetweenCalls` (default: 50): Delay between API calls in ms
 
 
+### export-comments
+
+Export all comments from a Ghost site as a CSV file. The output is compatible with the [Ghost Comment Importer](https://github.com/TryGhost/comment-importer), making it easy to migrate comments between Ghost sites.
+
+```sh
+# See all available options
+gctools export-comments --help
+
+# Export all published comments
+gctools export-comments <apiURL> <adminAPIKey>
+
+# Export comments with a specific status
+gctools export-comments <apiURL> <adminAPIKey> --status all
+
+# Export only hidden comments
+gctools export-comments <apiURL> <adminAPIKey> --status hidden
+
+# Verbose output
+gctools export-comments <apiURL> <adminAPIKey> -V
+```
+
+The exported CSV includes the columns required by the comment importer (`id`, `name`, `email`, `created_at`, `html`, `reply_to`, `post_id`) plus additional reference columns (`post_title`, `post_slug`, `post_url`) for easier review.
+
+The tool first tries the site-wide Admin API comments endpoint (available on newer Ghost versions). If unavailable, it falls back to fetching comments per-post via the public Members API and resolving member emails through the Admin API — making it compatible with Ghost 5.
+
+**Available options:**
+- `--status` (default: `published`): Filter by comment status (`all`, `published`, `hidden`)
+- `--delayBetweenCalls` (default: 50): Delay between API calls in ms
+
+
 ## Develop
 
 * `commands` handles the traditional CLI input

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,6 +49,7 @@ import addLabelToMembers from '../commands/add-label-to-members.js';
 import inlineMedia from '../commands/inline-media.js';
 import updatePostsFromJson from '../commands/update-posts-from-json.js';
 import seedDemo from '../commands/seed-demo.js';
+import exportComments from '../commands/export-comments.js';
 
 prettyCLI.command(addMemberCompSubscriptionCommands);
 prettyCLI.command(removeMemberCompSubscriptionCommands);
@@ -96,6 +97,7 @@ prettyCLI.command(addLabelToMembers);
 prettyCLI.command(inlineMedia);
 prettyCLI.command(updatePostsFromJson);
 prettyCLI.command(seedDemo);
+prettyCLI.command(exportComments);
 
 prettyCLI.style({
     usageCommandPlaceholder: () => '<source or utility>'

--- a/commands/export-comments.js
+++ b/commands/export-comments.js
@@ -1,0 +1,60 @@
+import {ui} from '@tryghost/pretty-cli';
+import exportComments from '../tasks/export-comments.js';
+
+const id = 'export-comments';
+
+const group = 'Content:';
+
+const flags = 'export-comments <apiURL> <adminAPIKey>';
+
+const desc = 'Export all comments from a Ghost site as a CSV compatible with the comment importer';
+
+const paramsDesc = [
+    'URL to your Ghost API',
+    'Admin API key'
+];
+
+const setup = (sywac) => {
+    sywac.boolean('-V --verbose', {
+        defaultValue: false,
+        desc: 'Show verbose output'
+    });
+    sywac.enumeration('--status', {
+        defaultValue: 'published',
+        choices: ['all', 'published', 'hidden'],
+        desc: 'Filter comments by status'
+    });
+    sywac.number('--delayBetweenCalls', {
+        defaultValue: 50,
+        desc: 'The delay between API calls, in ms'
+    });
+};
+
+const run = async (argv) => {
+    let timer = Date.now();
+    let context = {errors: []};
+
+    try {
+        let runner = exportComments.getTaskRunner(argv);
+        await runner.run(context);
+    } catch (error) {
+        ui.log.error('Done with errors', context.errors);
+    }
+
+    if (context.found && context.found.length > 0) {
+        ui.log.ok(`Successfully exported ${context.found.length} comments as CSV in ${Date.now() - timer}ms.`);
+        ui.log.info(`CSV saved to ${context.outputPath}`);
+    } else {
+        ui.log.warn('No comments found to export.');
+    }
+};
+
+export default {
+    id,
+    group,
+    flags,
+    desc,
+    paramsDesc,
+    setup,
+    run
+};

--- a/lib/admin-api-call.js
+++ b/lib/admin-api-call.js
@@ -82,9 +82,89 @@ const getRoles = async (options) => {
     }
 };
 
+const getComments = async (options) => {
+    const headers = apiAuthTokenHeaders(options);
+    let urlString = `${options.apiURL}/ghost/api/admin/comments/?limit=50&order=created_at%20asc`;
+
+    if (options.filter) {
+        let urlObj = new URL(urlString);
+        urlObj.searchParams.set('filter', options.filter);
+        urlString = urlObj.href;
+    }
+
+    let response = null;
+    let results = [];
+    let pageNumber = 1;
+
+    do {
+        let urlPageChange = new URL(urlString);
+        urlPageChange.searchParams.set('page', pageNumber);
+        urlString = urlPageChange.href;
+
+        response = await axios.get(urlString, {headers});
+        results = results.concat(response.data.comments);
+        pageNumber = response.data.meta.pagination.next;
+    } while (response.data.meta.pagination.next);
+
+    return results;
+};
+
+const getPublicCommentsForPost = async (options, postId) => {
+    let urlString = `${options.apiURL}/members/api/comments/?limit=50&order=created_at%20asc`;
+    let urlObj = new URL(urlString);
+    urlObj.searchParams.set('filter', `post_id:${postId}`);
+    urlString = urlObj.href;
+
+    let response = null;
+    let results = [];
+    let pageNumber = 1;
+
+    do {
+        let urlPageChange = new URL(urlString);
+        urlPageChange.searchParams.set('page', pageNumber);
+        urlString = urlPageChange.href;
+
+        response = await axios.get(urlString);
+        results = results.concat(response.data.comments);
+        pageNumber = response.data.meta.pagination.next;
+    } while (response.data.meta.pagination.next);
+
+    return results;
+};
+
+const getMembersByIds = async (options, memberIds) => {
+    if (memberIds.length === 0) {
+        return [];
+    }
+
+    const headers = apiAuthTokenHeaders(options);
+    let allMembers = [];
+    const batchSize = 50;
+
+    for (let i = 0; i < memberIds.length; i += batchSize) {
+        const batch = memberIds.slice(i, i + batchSize);
+        const filter = `id:[${batch.join(',')}]`;
+        let urlString = `${options.apiURL}/ghost/api/admin/members/?limit=${batchSize}`;
+        let urlObj = new URL(urlString);
+        urlObj.searchParams.set('filter', filter);
+
+        try {
+            const response = await axios.get(urlObj.href, {headers});
+            allMembers = allMembers.concat(response.data.members);
+        } catch (error) {
+            // Continue with remaining batches
+        }
+    }
+
+    return allMembers;
+};
+
 export {
     apiAuthTokenHeaders,
     getTiers,
     getMemberLabels,
-    getRoles
+    getRoles,
+    getComments,
+    getPublicCommentsForPost,
+    getMembersByIds
 };

--- a/tasks/export-comments.js
+++ b/tasks/export-comments.js
@@ -1,0 +1,211 @@
+import {writeFileSync} from 'node:fs';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import GhostAdminAPI from '@tryghost/admin-api';
+import {makeTaskRunner} from '@tryghost/listr-smart-renderer';
+import _ from 'lodash';
+import {getComments, getPublicCommentsForPost, getMembersByIds} from '../lib/admin-api-call.js';
+import {discover} from '../lib/batch-ghost-discover.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const escapeCSVField = (value) => {
+    const str = String(value ?? '');
+    if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+};
+
+const jsonToCSV = (data) => {
+    if (data.length === 0) {
+        return '';
+    }
+    const headers = Object.keys(data[0]);
+    const lines = [headers.join(',')];
+    for (const row of data) {
+        lines.push(headers.map(h => escapeCSVField(row[h])).join(','));
+    }
+    return lines.join('\n');
+};
+
+const extractSlugFromUrl = (url) => {
+    if (!url) {
+        return '';
+    }
+    const parts = url.replace(/\/$/, '').split('/');
+    return parts[parts.length - 1] || '';
+};
+
+const flattenComments = (comments, post) => {
+    let flat = [];
+
+    for (const comment of comments) {
+        const {replies, ...rest} = comment;
+        rest._post = post;
+        flat.push(rest);
+
+        if (replies && replies.length > 0) {
+            for (const reply of replies) {
+                reply.parent_id = comment.id;
+                reply._post = post;
+                flat.push(reply);
+            }
+        }
+    }
+
+    return flat;
+};
+
+const initialise = (options) => {
+    return {
+        title: 'Initialising API connection',
+        task: (ctx, task) => {
+            let defaults = {
+                verbose: false,
+                status: 'published',
+                delayBetweenCalls: 50
+            };
+
+            const url = options.apiURL.replace(/\/$/, '');
+            const key = options.adminAPIKey;
+            const api = new GhostAdminAPI({
+                url: url.replace('localhost', '127.0.0.1'),
+                key,
+                version: 'v5.0'
+            });
+
+            ctx.args = _.mergeWith(defaults, options);
+            ctx.args.apiURL = url;
+            ctx.api = api;
+            ctx.comments = [];
+            ctx.found = [];
+
+            task.output = `Initialised for ${options.apiURL}`;
+        }
+    };
+};
+
+const getFullTaskList = (options) => {
+    return [
+        initialise(options),
+        {
+            title: 'Fetching comments from Ghost API',
+            task: async (ctx, task) => {
+                let fetchOptions = {
+                    apiURL: ctx.args.apiURL,
+                    adminAPIKey: ctx.args.adminAPIKey
+                };
+
+                if (ctx.args.status && ctx.args.status !== 'all') {
+                    fetchOptions.filter = `status:${ctx.args.status}`;
+                }
+
+                // Try the site-wide Admin API endpoint first (newer Ghost versions)
+                try {
+                    ctx.comments = await getComments(fetchOptions);
+                    task.output = `Found ${ctx.comments.length} comments`;
+                    return;
+                } catch (error) {
+                    task.output = 'Site-wide endpoint unavailable, using Members API fallback...';
+                }
+
+                // Fallback: Members API public endpoint per post
+                let posts = await discover({
+                    api: ctx.api,
+                    type: 'posts',
+                    limit: 100,
+                    fields: 'id,title,slug,url',
+                    progress: ctx.args.verbose
+                });
+
+                task.output = `Found ${posts.length} posts, fetching comments for each...`;
+
+                let allComments = [];
+
+                for (const post of posts) {
+                    try {
+                        let postComments = await getPublicCommentsForPost(fetchOptions, post.id);
+                        if (postComments.length > 0) {
+                            allComments = allComments.concat(flattenComments(postComments, post));
+                        }
+                    } catch (error) {
+                        // Skip posts where comments can't be fetched
+                    }
+                }
+
+                // The public Members API doesn't include member emails,
+                // so look them up via the Admin API
+                let memberIds = [...new Set(
+                    allComments
+                        .map(c => c.member?.id)
+                        .filter(Boolean)
+                )];
+
+                if (memberIds.length > 0) {
+                    task.output = `Fetching email addresses for ${memberIds.length} members...`;
+                    let members = await getMembersByIds(fetchOptions, memberIds);
+                    let emailMap = new Map(members.map(m => [m.id, m.email]));
+
+                    for (const comment of allComments) {
+                        if (comment.member?.id && emailMap.has(comment.member.id)) {
+                            comment.member.email = emailMap.get(comment.member.id);
+                        }
+                    }
+                }
+
+                ctx.comments = allComments;
+                task.output = `Found ${ctx.comments.length} comments across ${posts.length} posts`;
+            }
+        },
+        {
+            title: 'Saving as CSV file',
+            task: async (ctx, task) => {
+                if (ctx.comments.length === 0) {
+                    task.output = 'No comments found, skipping CSV export';
+                    ctx.found = [];
+                    return;
+                }
+
+                let csvData = ctx.comments.map((comment) => {
+                    const post = comment.post || comment._post || {};
+                    const postUrl = post.url || '';
+                    const postSlug = post.slug || extractSlugFromUrl(postUrl);
+
+                    return {
+                        id: comment.id,
+                        name: comment.member?.name || '',
+                        email: comment.member?.email || '',
+                        created_at: comment.created_at,
+                        html: comment.html || '',
+                        reply_to: comment.parent_id || '',
+                        post_id: post.id || comment.post_id || '',
+                        post_title: post.title || '',
+                        post_slug: postSlug,
+                        post_url: postUrl
+                    };
+                });
+
+                let csv = jsonToCSV(csvData);
+                let fileName = `comments-export-${Date.now()}.csv`;
+                let outputPath = join(__dirname, '..', fileName);
+                writeFileSync(outputPath, csv);
+                ctx.outputPath = outputPath;
+                ctx.found = csvData;
+
+                task.output = `Exported ${csvData.length} comments to ${fileName}`;
+            }
+        }
+    ];
+};
+
+const getTaskRunner = (options) => {
+    let tasks = getFullTaskList(options);
+    return makeTaskRunner(tasks, Object.assign({topLevel: true}, options));
+};
+
+export default {
+    initialise,
+    getFullTaskList,
+    getTaskRunner
+};


### PR DESCRIPTION
## Summary

- Adds a new `export-comments` CLI tool that exports all comments from a Ghost site as a CSV compatible with the [Ghost Comment Importer](https://github.com/TryGhost/comment-importer)
- Supports both newer Ghost versions (site-wide Admin API endpoint) and Ghost 5 (per-post Members API fallback with Admin API member email lookup)
- Includes proper CSV escaping for fields containing commas, double quotes, and newlines

## CSV output

The exported CSV includes the columns required by the comment importer (`id`, `name`, `email`, `created_at`, `html`, `reply_to`, `post_id`) plus additional reference columns (`post_title`, `post_slug`, `post_url`) for review.

## Usage

```sh
gctools export-comments <apiURL> <adminAPIKey>
gctools export-comments <apiURL> <adminAPIKey> --status all
gctools export-comments <apiURL> <adminAPIKey> --status hidden
```

## Test plan

- [x] Tested against a Ghost site with native comments — produces valid CSV
- [x] Verify CSV imports cleanly with the comment importer's `validate` command
- [x] Test against a Ghost 5 site (Members API fallback path)